### PR TITLE
Improve templates and expand contributing guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -6,7 +6,13 @@ body:
   - type: markdown
     attributes:
       value: |
+        ## Please help us help you!
+
         Thank you for taking the time to fill out this bug report!
+
+        **The GitHub issue tracker is not a support forum**. If you are not sure whether the issue could be your mistakes, ask in the [GitHub discussions](https://github.com/WLAN-Pi/feedback/discussions) first. The quickest way to verify whether it's a WLAN Pi problem is through **reproduction**.
+
+        Make the bug obvious. Ideally, we should be able to understand the issue without running any code.
   - type: textarea
     id: what-happened
     attributes:
@@ -43,6 +49,15 @@ body:
         Please provide the version of software where this issue occurred.
     validations:
       required: true
+  - type: checkboxes
+    attributes:
+      label: Self Service
+      description: |
+        If you feel like you could contribute to this issue, please check the box below. This would tell us and other people looking for contributions that someone is working on it.
+        
+        If you do check this box, please send a pull request in the next week or two so we can still delegate this to someone else if you do not submit one.
+      options:
+        - label: I would be willing to fix this bug myself.
   - type: checkboxes
     id: contribs
     attributes:

--- a/.github/ISSUE_TEMPLATE/02-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.yml
@@ -15,6 +15,24 @@ body:
       placeholder: Tell us what you think could be enhanced and why.
     validations:
       required: true
+  - type: textarea
+    attributes:
+      label: Motivation
+      description: |
+        Please describe the motivation and why the feature should be implemented. Will this benefit a lot of users?
+
+        We may expect you to put your own work in this feature, particularly if the feature is not will not be requested by a lot of users. If the value of the feature is easy to understand, how the feature should work is clear, and will have big impact, we are more willing to help bring the feature to life.
+    validations:
+      required: true
+  - type: checkboxes
+    attributes:
+      label: Self Service
+      description: |
+        If you feel like you could contribute to this feature, please check the box below. This would tell us and other people looking for contributions that someone is working on it.
+        
+        If you do check this box, please send a pull request in the next week or two so we can still delegate this to someone else if you do not submit one.
+      options:
+        - label: I would be willing to fix this feature myself.
   - type: checkboxes
     id: contribs
     attributes:

--- a/.github/ISSUE_TEMPLATE/03-docs.yml
+++ b/.github/ISSUE_TEMPLATE/03-docs.yml
@@ -1,0 +1,50 @@
+name: 📚 Documentation
+description: Report an issue related to documentation
+title: "[DOCS]: <title>"
+labels: ['bug, untriaged']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This template is used for documentation requests, including:
+
+        - Documenting undocumented feature functionality
+        - Elaborating or expanding on a topic
+        - Updating linkrot
+        - Updating usage examples
+        - Anything that doesn't include modifying code
+
+        If you followed documentation but something still doesn't work, consider if the docs are wrong or the code is wrong. If the latter, use the bug report template instead.
+
+        If your docs update or request is:
+
+        - Relevant to a significant number of WLAN Pi users
+        - Not about external tools or packages not supported by WLAN PI
+        - Not documented elsewhere or easily discoverable
+
+        We will very likely accept and merge a related pull request. Go a head and make the pull request.
+
+        If you are not able to make the contribution yourself, we welcome the issue. 
+  - type: textarea
+    attributes:
+      label: Description
+      description: A succinct description of what the issue is.
+    validations:
+      required: true
+  - type: checkboxes
+    attributes:
+      label: Self Service
+      description: |
+        If you feel like you could contribute to this issue, please check the box below. This would tell us and other people looking for contributions that someone is working on it.
+        
+        If you do check this box, please send a pull request in the next week or two so we can still delegate this to someone else if you do not submit one.
+      options:
+        - label: I would be willing to fix this bug myself.
+  - type: checkboxes
+    id: contribs
+    attributes:
+      label: Guidelines and Policies
+      description: Please review our [contributing guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md), [code of conduct](https://github.com/WLAN-Pi/.github/blob/main/docs/code_of_conduct.md), and [disclaimer](https://github.com/WLAN-Pi/.github/blob/main/docs/disclaimer.md) before contributing.
+      options:
+        - label: I have read the contributing guidelines and agree to follow the code of conduct and contribution policies.
+          required: true

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,34 +1,49 @@
 # Contributing
 
-First off, thank you for being awesome and looking into contributing to the software powering WLAN Pi. We're thrilled that you'd like to contribute to this project. And it is people like you that make WLAN Pi a great tool. Please first review our policy, code of conduct, and developer guidelines below before proceeding.
+First off, thank you for being awesome and looking into contributing to the software powering the WLAN Pi. There are multiple projects that make up the applications and OS. If you're interested in contributing to WLAN Pi, hopefully, this page will help you.
 
-**Policy**:
+The [Open Source Guides](https://opensource.guide/) website has a useful collection of resources for folks who want to learn how to run and contribute to open source projects. Seasoned and people new to open source will find the guides useful.
 
-WLAN Pi does not endorse, support, or condone the use of its software for malicious, illegal, or unethical purposes, or to cause direct or indirect harm. By contributing to the software used by WLAN Pi, you agree to comply with all applicable laws and ethical standards. If you don't agree with these terms, do not contribute. Review our [disclaimer](disclaimer.md).
+- [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
 
-**Code of Conduct**:
+## Code of Conduct
 
-Please note that WLAN Pi releases software under the [Contributor Code of Conduct](code_of_conduct.md). By participating you agree to follow its terms. If you do not agree with our code of conduct, do not contribute.
+WLAN Pi adopts the [Contributor Code of Conduct](code_of_conduct.md) and expects contributors to adhere to. By participating you agree to follow its terms. Please read the full CoC text so you understand what is and is not acceptable behavior. If you do not agree with our code of conduct, please do not contribute.
 
-**Developer guidelines**:
+## Policy
 
-Your code contributions should follow the same conventions and pass the same code quality checks as the rest of the project. With that said, our documentation, style, and conventions are a work in progress welcome to suggestions for improvement. Check out [WLAN-Pi/developers](https://github.com/WLAN-Pi/developers) to find our developer docs around code style, workflow, and processes.
+Additionally, WLAN Pi does not endorse, support, or condone the use of its software for malicious, illegal, or unethical purposes, or to cause direct or indirect harm. By contributing to the software used by WLAN Pi, you agree to comply with all applicable laws and ethical standards. If you don't agree with these terms, please do not contribute. [Disclaimer](disclaimer.md).
 
-## Where do I go from here?
+## Getting Involved 
 
-If you've noticed a bug or have a specific feature request, make one! Notice multiple bugs? Create separately focused issues for each one.
+We're thrilled that you'd like to contribute to this project. And it is people like you that make WLAN Pi a great tool.
 
-Are you working on code already? Cool! Please open an issue (is it reproducible? how so?) or feature request (does it fit with the project?) before getting too far.
+There are different ways to contribute to WLAN Pi and some of them don't include writing any code.
 
-If you're fixing a bug, open an issue on the respective repo, and then submit and link a PR to that issue. For new features, you're awesome! Thanks! Please consider talking to a team member and starting a [discussion](https://github.com/WLAN-Pi/feedback/discussions/categories/general-feedback) before spending too much time on coding to make sure everyone is on the same page.
+- If you've noticed a bug or have a specific feature request, make one! Notice multiple bugs? Create separately focused issues for each one.
 
-Have you never contributed to open source before? That's OK! Contributing to open source could be anything from updating documentation, triaging issues and bugs, or writing code. You should check out the resources at the bottom of this post if are new to this.
+- Are you working on code already? Cool! Please open an issue (is it reproducible? how so?) or feature request (does it fit with the project?) before getting too far.
+
+- If you're fixing a bug, open an issue on the respective repo, and then submit and link a PR to that issue. For new features, you're awesome! Thanks! Please consider talking to a team member and starting a [discussion](https://github.com/WLAN-Pi/feedback/discussions/categories/general-feedback) before spending too much time on coding to make sure everyone is on the same page.
+
+- Have you never contributed to open source before? That's OK! Contributing to open source could be anything from updating documentation, triaging issues and bugs, or writing code.
+
+## Triaging Issues and Pull Requests
+
+One way you can contribute without writing any code is to help triage issues and pull requests.
+
+- Ask for more information if you believe there is not enough details to solve the issue.
+- Flag issues that are stale or that should be closed.
+- Ask for test plans and review code.
+
+Unsure what Pull Requests are?
+
+- [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)
 
 ## Questions
 
-The GitHub issue tracker is for *bug reports* and *feature requests*. Please do
-not use it to ask questions about usage. These questions should
-instead be directed through discussions from the link in the section above. 
+Please note that the various GitHub issue trackers are mostly for *bug reports* and *feature requests*. Please do
+not use GitHub issues to ask questions about usage. These questions should instead be directed through the [feedback discussions](https://github.com/WLAN-Pi/feedback).
 
 ## Good Bug Reports
 
@@ -68,7 +83,44 @@ If you do not provide all of these things, it can take us much longer to
 fix your problem. If we ask you to clarify these and you never respond, we
 will close your issue without fixing it.
 
+## Development Process
+
+WLAN Pi uses [GitHub](https://github.com/wlan-pi) as our source of truth. The core team works directly here and all changes are public.
+
+Pull Requests will be checked using GitHub actions to run tests, style tests, builds, and more.
+
+### Issues
+
+When opening a new issue, always make sure to fill out the issue template. This step is very important! Not doing so may result in your issue not being managed in a timely fashion. Don't take this personally if this happens, and feel free to open a new issue once you've gathered all the information required by the template.
+
+Again, please don't use the GitHub issue tracker for questions. If you have questions about using WLAN Pi, use any of our support channels, and we will do our best to answer your questions.
+
+### Bugs
+
+WLAN Pi uses GitHub Issues for our public bugs. If you would like to report a problem, take a look around and see if someone already opened an issue about it. If you are certain this is a new, unreported bug, please submit a bug report.
+
+- One issue, one bug: Please report a single bug per issue.
+- Provide reproduction steps: List all the steps necessary to reproduce the issue. The person reading your bug report should be able to follow these steps to reproduce your issue with minimal effort.
+
+If you're only fixing a bug, it's fine to submit a pull request right away but we still recommend filing an issue detailing what you're fixing. This is helpful in case we don't accept that specific fix but want to keep track of the issue. The PR should be closing an issue #.
+
+## Development 
+
+Your code contributions should follow the same conventions and pass the same code quality checks as the rest of the project. Take a look around at the rest of the code in the particular project for ideas. Match the style you see used throughout the project such as formatting, naming files, etc.
+
+If you're writing documentation, please do not wrap lines. Configure your editor to soft wrap for documentation.
+
+With that said, our documentation, style, and conventions are a work in progress welcome to suggestions for improvement. Check out [WLAN-Pi/developers](https://github.com/WLAN-Pi/developers) to find our developer docs around code style, workflow, and processes.
+
 ## Submitting a pull request
+
+Ok, so you want to contribute code to WLAN Pi by opening a pull request. You're invested. Thank you, we appreciate this.
+
+Checklist:
+
+0. Keep your PR small. These are easier to review and get merged. Your PR in general should only do one thing. Otherwise, likely needs split into multiple PRs.
+0. Use descriptive titles. Start with feat, fix, docs, refactor, test, or chore. Follow with a summary in present tense. for example: `fix: fix FPMS crash`.
+0. Test your changes. Describe how to test and validate your contribution.
 
 Generally, this is the process you'll follow:
 
@@ -82,6 +134,18 @@ Generally, this is the process you'll follow:
 0. Pat your self on the back and wait for your pull request to be reviewed and merged
 
 We use Github Actions which will run our CI/CD to archive and deploy packages. In some repos, Github actions will run test suites and other checks. These must pass before a PR will be accepted and merged.
+
+## Breaking Changes
+
+If you're adding breaking changes, make sure to note that in the PR.
+
+
+```
+0. Who is affected
+0. What needs migrated
+0. Why this breaking change
+0. Severity
+```
 
 ## Get the documentation right
 
@@ -108,7 +172,7 @@ A PR should only be merged into `main` by a maintainer if:
 * It has no requested changes.
 * It is up to date with current `main` and does not erase or re-write history.
 
-Any maintainer is allowed to merge a PR if all of these conditions are met.
+Any maintainer is allowed to merge a PR if all of these conditions are met. PRs should be squash-merged into the `main` branch. 
 
 ## Shipping a release (maintainers only)
 
@@ -118,17 +182,3 @@ Maintainers need to do the following to push out a release:
 * Update the version info in `debian/changelog` which will trigger a workflow on push to build and deploy a new version of the package to packagecloud. This CI will also check that the Python package version (`<package>/__version__.py`) aligns with the Debian package version (`debian/changelog`).
 * Update release notes accordingly
 
-## Resources
-
-Start here:
-
-- [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
-- [Figuring out how to contribute to open source](https://jvns.ca/blog/2017/08/06/contributing-to-open-source/)
-
-Then you'll need to understand Pull Requests:
-
-- [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)
-
-The GitHub help can also be a useful place for those who are unfamiliar:
-
-- [GitHub Help](https://help.github.com)

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,18 +1,44 @@
-## Description
+## Type of change 
 
-*Please describe what changes you made, and why you feel they are necessary. Make sure to include code examples, where applicable.*
+* [ ] Bug fix (non-breaking change that fixes something)
+* [ ] New feature (non-breaking change adding functionality)
+* [ ] Breaking change (fix or feature changing existing functionality)
+* [ ] Code quality improvement (refactor, performance improvements)
+* [ ] Documentation update (readme, changelog, man page, etc.)
+* [ ] Other (please specify):
+
+## Breaking change
+
+*Does this Pull Request introduce a breaking change?* 
+
+- What functionality breaks?
+- Why does it break?
+- How should it be migrated?  
+- Are there any backward-compatible alternatives?
+
+## Proposed change
+
+*Please describe the purpose of this change, the problem it solves, and why the change is necessary. Include code snippets or links to related documentation when applicable*
 
 ## Testing
 
-*Please explain how you tested this change manually, and, if applicable, what new tests you added.
+*Please explain how you tested this change manually, and if applicable, what new tests you added.*
+
+- [ ] Did you add new automated tests? If yes, explain which edge cases are covered.
+- [ ] Does this change affect any existing tests? If so, how did you adjust them?
+- [ ] Please provide test run results or screenshots if applicable.
 
 ## Checklist
 
 * [ ] I have read the [contribution guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
-* [ ] I have targeted this PR against the correct branch
-* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly approved via an issue
-* [ ] I ran the test suite and verified that it succeeded
+* [ ] I have targeted this PR against the correct git branch
+* [ ] I ran the test suite and verified it succeeded
+* [ ] I linked an approved GitHub issue to this PR (next section)
+* [ ] I have updated the changelog (if applicable)
+* [ ] I have added or updated the documentation (if applicable)
 
-## Closes
+## Related Issues/PRs 
 
-This PR closes corresponding issue #.
+- This PR fixes/closes issue #
+- This PR is related to issue #
+- This PR depends on/blocks PR #


### PR DESCRIPTION
## Description

This PR improves the existing organization issue templates, adds an issue template for docs, updates the PR template, and expands on the contributing guidelines.

## Checklist

* [X] I have read the [contribution guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
* [X] I have targeted this PR against the correct branch
* [X] This is either a bugfix, a documentation update, or a new feature that has been explicitly approved via an issue