### PR TITLE
docs: simplify PR and issue templates to reduce contributor friction

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,75 +1,39 @@
 name: 🐛 Bug report
 description: Create a report to help us fix something
 title: "[BUG]: <title>"
-labels: ['bug, untriaged']
+labels: ['bug', 'untriaged']
 body:
   - type: markdown
     attributes:
       value: |
-        ## Please help us help you!
-
-        Thank you for taking the time to fill out this bug report!
-
-        **The GitHub issue tracker is not a support forum**. If you are not sure whether the issue could be your mistakes, ask in the [GitHub discussions](https://github.com/WLAN-Pi/feedback/discussions) first. The quickest way to verify whether it's a WLAN Pi problem is through **reproduction**.
-
-        Make the bug obvious. Ideally, we should be able to understand the issue without running any code.
+        Before filing, check if this issue already exists. For usage questions, use [discussions](https://github.com/WLAN-Pi/feedback/discussions) instead.
   - type: textarea
     id: what-happened
     attributes:
       label: What happened?
-      description: What did you expect?
-      placeholder: Tell us what happened and what you expected instead.
+      description: What did you expect to happen instead?
+      placeholder: Describe the bug and what you expected.
     validations:
       required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: "1. ...\n2. ...\n3. ..."
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Version
+      description: WLAN Pi OS version, package version, or any other relevant version reference.
+      placeholder: e.g. 2.3.1
+    validations:
+      required: false
   - type: textarea
     id: logs
     attributes:
       label: Relevant log output
-      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
-      value: 
+      description: Optional but very helpful.
       render: shell
     validations:
-      required: true
-  - type: dropdown
-    attributes:
-      label: How often does this bug happen?
-      description: |
-        Following the repro steps above, how easily are you able to reproduce this bug?
-      options:
-        - Every time
-        - Often
-        - Sometimes
-        - Only once
-    validations:
-      required: true
-  - type: input
-    attributes:
-      label: What version are you using?
-      description: |
-        Please provide the version of software where this issue occurred.
-    validations:
-      required: true
-  - type: input
-    attributes:
-      label: Where is the bug located?
-      description: |
-        If known, please provide a link to where you think the bug exists in the code.
-    validations:
       required: false
-  - type: checkboxes
-    attributes:
-      label: Self Service
-      description: |
-        If you feel like you could contribute to this issue, please check the box below. This would tell us and other people looking for contributions that someone is working on it.
-        
-        If you do check this box, please send a pull request in the next week or two so we can still delegate this to someone else if you do not submit one.
-      options:
-        - label: I would be willing to fix this bug myself.
-  - type: checkboxes
-    id: contribs
-    attributes:
-      label: Guidelines and Policies
-      description: Please review our [contributing guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md), [code of conduct](https://github.com/WLAN-Pi/.github/blob/main/docs/code_of_conduct.md), and [disclaimer](https://github.com/WLAN-Pi/.github/blob/main/docs/disclaimer.md) before contributing.
-      options:
-        - label: I have read the contributing guidelines and agree to follow the code of conduct and contribution policies.
-          required: true

--- a/.github/ISSUE_TEMPLATE/02-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.yml
@@ -1,43 +1,12 @@
 name: 💡 Feature request
-description: Create a feature request
+description: Suggest an idea or enhancement
 title: "[FEATURE]: <title>"
-labels: ['feature, untriaged']
+labels: ['feature', 'untriaged']
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thank you for taking the time to fill out this feature or enhancement request!
   - type: textarea
     id: feature
     attributes:
-      label: What is the feature?
-      description: What do you want this feature to do?
-      placeholder: Tell us what you think could be enhanced and why.
+      label: What would you like?
+      placeholder: Describe the feature and what problem it solves.
     validations:
       required: true
-  - type: textarea
-    attributes:
-      label: Motivation
-      description: |
-        Please describe the motivation and why the feature should be implemented. Will this benefit a lot of users?
-
-        We may expect you to put your own work in this feature, particularly if the feature is not will not be requested by a lot of users. If the value of the feature is easy to understand, how the feature should work is clear, and will have big impact, we are more willing to help bring the feature to life.
-    validations:
-      required: true
-  - type: checkboxes
-    attributes:
-      label: Self Service
-      description: |
-        If you feel like you could contribute to this feature, please check the box below. This would tell us and other people looking for contributions that someone is working on it.
-        
-        If you do check this box, please send a pull request in the next week or two so we can still delegate this to someone else if you do not submit one.
-      options:
-        - label: I would be willing to fix this feature myself.
-  - type: checkboxes
-    id: contribs
-    attributes:
-      label: Guidelines and Policies
-      description: Please review our [contributing guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md), [code of conduct](https://github.com/WLAN-Pi/.github/blob/main/docs/code_of_conduct.md), and [disclaimer](https://github.com/WLAN-Pi/.github/blob/main/docs/disclaimer.md) before contributing.
-      options:
-        - label: I have read the contributing guidelines and agree to follow the code of conduct and contribution policies.
-          required: true

--- a/.github/ISSUE_TEMPLATE/03-docs.yml
+++ b/.github/ISSUE_TEMPLATE/03-docs.yml
@@ -1,50 +1,11 @@
 name: 📚 Documentation
-description: Report an issue related to documentation
+description: Report a documentation issue or request an improvement
 title: "[DOCS]: <title>"
-labels: ['bug, untriaged']
+labels: ['documentation', 'untriaged']
 body:
-  - type: markdown
-    attributes:
-      value: |
-        This template is used for documentation requests, including:
-
-        - Documenting undocumented feature functionality
-        - Elaborating or expanding on a topic
-        - Updating linkrot
-        - Updating usage examples
-        - Anything that doesn't include modifying code
-
-        If you followed documentation but something still doesn't work, consider if the docs are wrong or the code is wrong. If the latter, use the bug report template instead.
-
-        If your docs update or request is:
-
-        - Relevant to a significant number of WLAN Pi users
-        - Not about external tools or packages not supported by WLAN PI
-        - Not documented elsewhere or easily discoverable
-
-        We will very likely accept and merge a related pull request. Go a head and make the pull request.
-
-        If you are not able to make the contribution yourself, we welcome the issue. 
   - type: textarea
     attributes:
-      label: Description
-      description: A succinct description of what the issue is.
+      label: What needs to be updated?
+      description: Link to the relevant doc if you can.
     validations:
       required: true
-  - type: checkboxes
-    attributes:
-      label: Self Service
-      description: |
-        If you feel like you could contribute to this issue, please check the box below. This would tell us and other people looking for contributions that someone is working on it.
-        
-        If you do check this box, please send a pull request in the next week or two so we can still delegate this to someone else if you do not submit one.
-      options:
-        - label: I would be willing to fix this bug myself.
-  - type: checkboxes
-    id: contribs
-    attributes:
-      label: Guidelines and Policies
-      description: Please review our [contributing guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md), [code of conduct](https://github.com/WLAN-Pi/.github/blob/main/docs/code_of_conduct.md), and [disclaimer](https://github.com/WLAN-Pi/.github/blob/main/docs/disclaimer.md) before contributing.
-      options:
-        - label: I have read the contributing guidelines and agree to follow the code of conduct and contribution policies.
-          required: true

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,40 +1,10 @@
 ## Summary
 
-<!-- Briefly describe the change and why it's needed -->
-
-## Type of change
-
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Breaking change
-- [ ] Documentation
-- [ ] Other: 
-
-## Proposed change
-
-<!-- What problem does this solve? What was changed? -->
+<!-- What does this PR do and why? If it closes an issue, note it here: closes #123 -->
+<!-- If this introduces breaking changes, describe what breaks and what needs to migrate. -->
 
 ## Testing
 
-<!-- How was this tested? -->
-- [ ] Added/updated automated tests
-- [ ] Tested manually on a WLAN Pi
-- [ ] Tested in another environment
+<!-- How did you test this? -->
 
-## AI assistance
-
-- [ ] I used AI/LLM assistance
-- If yes: Tool(s) used: 
-
-## Checklist
-
-- [ ] I have read the [contribution guidelines](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
-- [ ] I targeted the correct branch (in general: `dev` for features/fixes, `main` for hotfixes)
-- [ ] This PR fixes/closes issue #_ (or relates to issue #_)
-
-## Breaking changes
-
-<!-- Only fill out if you checked "Breaking change" above -->
-
-- **What breaks:** 
-- **Migration needed:** 
+> AI assistance is welcome. Just make sure you have reviewed and tested what you are submitting.


### PR DESCRIPTION
## Summary

Simplifies PR and issue templates across the board to reduce friction for contributors.

### Changes

**PR template**
- Removed type-of-change checkboxes
- Removed AI tool interrogation, replaced with a single short nudge
- Removed verbose breaking changes section, folded into Summary comment
- Removed checklist
- Free-text testing field only

**Bug report**
- Made logs optional
- Made version optional and generic (covers OS, package, or any version)
- Removed mandatory policy checkbox
- Fixed label format (was a single string `bug, untriaged`, now separate labels)
- Added steps to reproduce as a distinct field

**Feature request**
- Reduced to a single field
- Removed motivation lecture and alternatives field
- Fixed label format
- Removed policy checkbox

**Docs template**
- Fixed label (`bug, untriaged` -> `documentation` + `untriaged`)
- Reduced to a single field
- Removed preamble