### PR TITLE
Add CODEOWNERS, fix config.yml, update AI assistance blurbs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @joshschmelzle

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: 
   - name: 🤔 Questions and help
     url: https://github.com/orgs/WLAN-Pi/discussions
     about: This issue tracker is not for support questions. Please use the WLAN Pi discussions page instead.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -10,9 +10,9 @@ WLAN Pi adopts the [Contributor Code of Conduct](code_of_conduct.md). By partici
 
 WLAN Pi does not endorse, support, or condone the use of its software for malicious, illegal, or unethical purposes. By contributing, you agree to comply with all applicable laws and ethical standards. [Disclaimer](disclaimer.md).
 
-## AI and LLM assistance disclosure
+## AI assistance
 
-Please disclose if you've used AI tools (GitHub Copilot, ChatGPT, Claude, Gemini, Moonshot, etc.) to assist in developing your contribution. Mention any AI assistance in your PR description.
+AI assistance is welcome. Just make sure you have reviewed and tested what you are submitting.
 
 ## Getting involved
 

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -7,4 +7,4 @@
 
 <!-- How did you test this? -->
 
-> AI assistance is welcome. Just make sure you have reviewed and tested what you are submitting.
+> AI assistance is welcome. Just make sure you have reviewed and tested what you are submitting. Large PRs take longer to review. Keep changes focused when you can.


### PR DESCRIPTION
Add CODEOWNERS with default reviewer, remove blank entry from config.yml, and make AI assistance language consistent across contributing docs and PR template.

- `.github/CODEOWNERS`: add default reviewer (@joshschmelzle)
- `.github/ISSUE_TEMPLATE/config.yml`: remove blank name entry
- `docs/contributing.md`: replace verbose AI disclosure section with one-liner matching PR template
- `docs/pull_request_template.md`: add note that large PRs take longer to review