### PR TITLE
Make the AI-assistance note an HTML comment in the PR template

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -7,4 +7,4 @@
 
 <!-- How did you test this? -->
 
-> AI assistance is welcome. Just make sure you have reviewed and tested what you are submitting. Large PRs take longer to review. Keep changes focused when you can.
+<!-- AI assistance is welcome. Just make sure you have reviewed and tested what you are submitting. Large PRs take longer to review. Keep changes focused when you can. -->


### PR DESCRIPTION
Converts the AI-assistance blockquote to an HTML comment, matching the other template hints. Authors see it while writing, but it no longer renders in every submitted PR description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)